### PR TITLE
feat(types): add initial types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,17 @@ export type ResumePoint = {
   resume_position_ms: number;
 };
 
+export type Category = {
+  href: string;
+  icons: Image[];
+  id: string;
+  name: string;
+};
+
+export type Categories = {
+  categories: Page<Category>;
+};
+
 export type SimplifiedChapter = {
   available_markets: string[];
   chapter_number: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,41 @@ export type Chapter = SimplifiedChapter & {
   audiobook: SimplifiedAudiobook;
 };
 
+export type SimplifiedEpisode = {
+  description: string;
+  html_description: string;
+  duration_ms: number;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  images: Image[];
+  is_externally_hosted: boolean;
+  is_playable: boolean;
+  language: string;
+  languages: string[];
+  name: string;
+  release_date: string;
+  release_date_precision: string;
+  resume_point: ResumePoint;
+  type: string;
+  uri: string;
+  restrictions: Restrictions;
+};
+
+export type Episode = SimplifiedEpisode & {
+  show: SimplifiedShow;
+};
+
+export type Episodes = {
+  episodes: Episode[];
+};
+
+export type SavedEpisode = {
+  added_at: string;
+  episode: Episode;
+};
+
 export type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,3 +267,75 @@ export type Track = SimplifiedTrack & {
 export type TopTracksResult = {
   tracks: Track[];
 };
+
+export type TrackItem = Track | Episode;
+
+export type Actions = {
+  interrupting_playback: boolean;
+  pausing: boolean;
+  resuming: boolean;
+  seeking: boolean;
+  skipping_next: boolean;
+  skipping_prev: boolean;
+  toggling_repeat_context: boolean;
+  toggling_shuffle: boolean;
+  toggling_repeat_track: boolean;
+  transferring_playback: boolean;
+};
+
+export type PlaybackState = {
+  device: Device;
+  repeat_state: string;
+  shuffle_state: boolean;
+  context: Context | null;
+  timestamp: number;
+  progress_ms: number;
+  is_playing: boolean;
+  item: TrackItem;
+  currently_playing_type: string;
+  actions: Actions;
+};
+
+export type Device = {
+  id: string | null;
+  is_active: boolean;
+  is_private_session: boolean;
+  is_restricted: boolean;
+  name: string;
+  type: string;
+  volume_percent: number | null;
+};
+
+export type Devices = {
+  devices: Device[];
+};
+
+export type Context = {
+  type: string;
+  href: string;
+  external_urls: ExternalUrls;
+  uri: string;
+};
+
+export type RecentlyPlayedTracks = {
+  href: string;
+  limit: number;
+  next: string | null;
+  cursors: {
+    after: string;
+    before: string;
+  };
+  total: number;
+  items: PlayHistory[];
+};
+
+export type PlayHistory = {
+  track: Track;
+  played_at: string;
+  context: Context;
+};
+
+export type Queue = {
+  currently_playing: TrackItem | null;
+  queue: TrackItem[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,136 @@
+export type Page<TItemType> = {
+  href: string;
+  items: TItemType[];
+  limit: number;
+  next: string | null;
+  offset: number;
+  previous: string | null;
+  total: number;
+};
+
+export type Copyright = {
+  text: string;
+  type: string;
+};
+
+export type Image = {
+  url: string;
+  height: number;
+  width: number;
+};
+
+export type Restrictions = {
+  reason: string;
+};
+
+export type ExternalIds = {
+  isrc: string;
+  ean: string;
+  upc: string;
+};
+
+export type ExternalUrls = {
+  spotify: string;
+};
+
+export type Followers = {
+  href: string | null;
+  total: number;
+};
+
+export type SimplifiedArtist = {
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  name: string;
+  type: string;
+  uri: string;
+};
+
+export type Artist = SimplifiedArtist & {
+  followers: Followers;
+  genres: string[];
+  images: Image[];
+  popularity: number;
+};
+
+export type LinkedFrom = {
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  type: string;
+  uri: string;
+};
+
+export type SimplifiedTrack = {
+  artists: SimplifiedArtist[];
+  available_markets: string[];
+  dics_number: number;
+  duration_ms: number;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  is_playable: boolean;
+  linked_from: LinkedFrom;
+  restrictions: Restrictions;
+  name: string;
+  track_number: number;
+  type: string;
+  uri: string;
+  is_local: boolean;
+};
+
+export type AlbumBase = {
+  album_type: string;
+  available_markets: string[];
+  copyrights: Copyright[];
+  external_ids: ExternalIds;
+  external_urls: ExternalUrls;
+  genres: string[];
+  href: string;
+  id: string;
+  images: Image[];
+  label: string;
+  name: string;
+  popularity: number;
+  release_date: string;
+  release_date_precision: string;
+  restrictions?: Restrictions;
+  total_tracks: number;
+  type: string;
+  uri: string;
+};
+
+export type SimplifiedAlbum = AlbumBase & {
+  album_group: string;
+  artists: SimplifiedArtist[];
+};
+
+export type SavedAlbum = {
+  added_at: string;
+  album: Album;
+};
+
+export type Album = AlbumBase & {
+  artists: Artist[];
+  tracks: Page<SimplifiedTrack>;
+};
+
+export type Albums = {
+  albums: Album[];
+};
+
+export type AlbumTrack = {
+  href: string;
+  limit: number;
+  next: string;
+  offset: number;
+  previous: string;
+  total: number;
+  items: SimplifiedTrack[];
+};
+
+export type NewReleases = {
+  albums: Page<SimplifiedAlbum>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,10 @@ type Artists = {
   artists: Artist[];
 };
 
+type FollowedArtists = {
+  artists: Artist[];
+};
+
 type AlbumBase = {
   album_type: string;
   available_markets: string[];
@@ -508,6 +512,36 @@ type SimplifiedPlaylist = PlaylistBase & {
 type TrackReference = {
   href: string;
   total: number;
+};
+
+type UserReference = {
+  display_name: string;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  type: string;
+  uri: string;
+};
+
+type User = {
+  display_name: string;
+  email: string;
+  external_urls: ExternalUrls;
+  followers: Followers;
+  href: string;
+  id: string;
+  images: Image[];
+  type: string;
+  uri: string;
+};
+
+type UserProfile = User & {
+  country: string;
+  explicit_content: {
+    filter_enabled: boolean;
+    filter_locked: boolean;
+  };
+  product: string;
 };
 
 type TrackItem = Track | Episode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,71 @@ export type NewReleases = {
   albums: Page<SimplifiedAlbum>;
 };
 
+export type Author = {
+  name: string;
+};
+
+export type Narrator = {
+  name: string;
+};
+
+export type SimplifiedAudiobook = {
+  authors: Author[];
+  available_markets: string[];
+  copyrights: Copyright[];
+  description: string;
+  edition: string;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  html_description: string;
+  id: string;
+  images: Image[];
+  languages: string[];
+  media_type: string;
+  name: string;
+  narrators: Narrator[];
+  publisher: string;
+  total_chapters: number;
+  type: string;
+  uri: string;
+};
+
+export type Audiobook = SimplifiedAudiobook & {
+  chapters: Page<SimplifiedChapter>;
+};
+
+export type Audiobooks = {
+  audiobooks: Audiobook[];
+};
+
+export type ResumePoint = {
+  fully_played: boolean;
+  resume_position_ms: number;
+};
+
+export type SimplifiedChapter = {
+  available_markets: string[];
+  chapter_number: number;
+  description: string;
+  html_description: string;
+  duration_ms: number;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  images: Image[];
+  is_playable: boolean;
+  languages: string[];
+  name: string;
+  release_date: string;
+  release_date_precision: string;
+  resume_point: ResumePoint;
+  type: string;
+  uri: string;
+  restrictions: Restrictions;
+};
+
 export type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,61 @@ export type TopTracksResult = {
   tracks: Track[];
 };
 
+export type SnapshotReference = {
+  snapshot_id: string;
+};
+
+export type PlaylistBase = {
+  collaborative: boolean;
+  description: string;
+  external_urls: ExternalUrls;
+  followers: Followers;
+  href: string;
+  id: string;
+  images: Image[];
+  name: string;
+  owner: UserReference;
+  primary_color: string;
+  public: boolean;
+  snapshot_id: string;
+  type: string;
+  uri: string;
+};
+
+export type PlaylistedTrack<Item extends TrackItem = TrackItem> = {
+  added_at: string;
+  added_by: AddedBy;
+  is_local: boolean;
+  primary_color: string;
+  track: Item;
+};
+
+export type AddedBy = {
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  type: string;
+  uri: string;
+};
+
+export type Playlist<Item extends TrackItem = TrackItem> = PlaylistBase & {
+  tracks: Page<PlaylistedTrack<Item>>;
+};
+
+export type FeatureedPlaylists = {
+  message: string;
+  playlists: Page<SimplifiedPlaylist>;
+};
+
+export type SimplifiedPlaylist = PlaylistBase & {
+  tracks: TrackReference | null;
+};
+
+export type TrackReference = {
+  href: string;
+  total: number;
+};
+
 export type TrackItem = Track | Episode;
 
 export type Actions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,39 @@ type SavedEpisode = {
   episode: Episode;
 };
 
+type SimplifiedShow = {
+  available_markets: string[];
+  copyrights: Copyright[];
+  description: string;
+  html_description: string;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  images: Image[];
+  is_externally_hosted: boolean;
+  languages: string[];
+  media_type: string;
+  name: string;
+  publisher: string;
+  type: string;
+  uri: string;
+  total_episodes: number;
+};
+
+type Show = SimplifiedShow & {
+  episodes: Page<SimplifiedEpisode>;
+};
+
+type Shows = {
+  shows: Show[];
+};
+
+type SavedShow = {
+  added_at: string;
+  show: SimplifiedShow;
+};
+
 type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Page<TItemType> = {
+type Page<TItemType> = {
   href: string;
   items: TItemType[];
   limit: number;
@@ -8,37 +8,47 @@ export type Page<TItemType> = {
   total: number;
 };
 
-export type Copyright = {
+type Copyright = {
   text: string;
   type: string;
 };
 
-export type Image = {
+type Image = {
   url: string;
   height: number;
   width: number;
 };
 
-export type Restrictions = {
+type Restrictions = {
   reason: string;
 };
 
-export type ExternalIds = {
+type ExternalIds = {
   isrc: string;
   ean: string;
   upc: string;
 };
 
-export type ExternalUrls = {
+type ExternalUrls = {
   spotify: string;
 };
 
-export type Followers = {
+type Followers = {
   href: string | null;
   total: number;
 };
 
-export type LinkedFrom = {
+type SearchResultsMap = {
+  albums: SimplifiedAlbum;
+  artists: Artist;
+  tracks: Track;
+  playlists: SimplifiedPlaylist;
+  shows: SimplifiedShow;
+  episodes: SimplifiedEpisode;
+  audiobooks: SimplifiedAudiobook;
+};
+
+type LinkedFrom = {
   external_urls: ExternalUrls;
   href: string;
   id: string;
@@ -46,7 +56,7 @@ export type LinkedFrom = {
   uri: string;
 };
 
-export type SimplifiedArtist = {
+type SimplifiedArtist = {
   external_urls: ExternalUrls;
   href: string;
   id: string;
@@ -55,18 +65,18 @@ export type SimplifiedArtist = {
   uri: string;
 };
 
-export type Artist = SimplifiedArtist & {
+type Artist = SimplifiedArtist & {
   followers: Followers;
   genres: string[];
   images: Image[];
   popularity: number;
 };
 
-export type Artists = {
+type Artists = {
   artists: Artist[];
 };
 
-export type AlbumBase = {
+type AlbumBase = {
   album_type: string;
   available_markets: string[];
   copyrights: Copyright[];
@@ -87,26 +97,26 @@ export type AlbumBase = {
   uri: string;
 };
 
-export type SimplifiedAlbum = AlbumBase & {
+type SimplifiedAlbum = AlbumBase & {
   album_group: string;
   artists: SimplifiedArtist[];
 };
 
-export type SavedAlbum = {
+type SavedAlbum = {
   added_at: string;
   album: Album;
 };
 
-export type Album = AlbumBase & {
+type Album = AlbumBase & {
   artists: Artist[];
   tracks: Page<SimplifiedTrack>;
 };
 
-export type Albums = {
+type Albums = {
   albums: Album[];
 };
 
-export type AlbumTrack = {
+type AlbumTrack = {
   href: string;
   limit: number;
   next: string;
@@ -116,19 +126,19 @@ export type AlbumTrack = {
   items: SimplifiedTrack[];
 };
 
-export type NewReleases = {
+type NewReleases = {
   albums: Page<SimplifiedAlbum>;
 };
 
-export type Author = {
+type Author = {
   name: string;
 };
 
-export type Narrator = {
+type Narrator = {
   name: string;
 };
 
-export type SimplifiedAudiobook = {
+type SimplifiedAudiobook = {
   authors: Author[];
   available_markets: string[];
   copyrights: Copyright[];
@@ -150,31 +160,31 @@ export type SimplifiedAudiobook = {
   uri: string;
 };
 
-export type Audiobook = SimplifiedAudiobook & {
+type Audiobook = SimplifiedAudiobook & {
   chapters: Page<SimplifiedChapter>;
 };
 
-export type Audiobooks = {
+type Audiobooks = {
   audiobooks: Audiobook[];
 };
 
-export type ResumePoint = {
+type ResumePoint = {
   fully_played: boolean;
   resume_position_ms: number;
 };
 
-export type Category = {
+type Category = {
   href: string;
   icons: Image[];
   id: string;
   name: string;
 };
 
-export type Categories = {
+type Categories = {
   categories: Page<Category>;
 };
 
-export type SimplifiedChapter = {
+type SimplifiedChapter = {
   available_markets: string[];
   chapter_number: number;
   description: string;
@@ -196,15 +206,15 @@ export type SimplifiedChapter = {
   restrictions: Restrictions;
 };
 
-export type Chapters = {
+type Chapters = {
   chapters: Chapter[];
 };
 
-export type Chapter = SimplifiedChapter & {
+type Chapter = SimplifiedChapter & {
   audiobook: SimplifiedAudiobook;
 };
 
-export type SimplifiedEpisode = {
+type SimplifiedEpisode = {
   description: string;
   html_description: string;
   duration_ms: number;
@@ -226,20 +236,20 @@ export type SimplifiedEpisode = {
   restrictions: Restrictions;
 };
 
-export type Episode = SimplifiedEpisode & {
+type Episode = SimplifiedEpisode & {
   show: SimplifiedShow;
 };
 
-export type Episodes = {
+type Episodes = {
   episodes: Episode[];
 };
 
-export type SavedEpisode = {
+type SavedEpisode = {
   added_at: string;
   episode: Episode;
 };
 
-export type SimplifiedTrack = {
+type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];
   dics_number: number;
@@ -258,21 +268,21 @@ export type SimplifiedTrack = {
   is_local: boolean;
 };
 
-export type Track = SimplifiedTrack & {
+type Track = SimplifiedTrack & {
   album: SimplifiedAlbum;
   external_ids: ExternalIds;
   popularity: number;
 };
 
-export type TopTracksResult = {
+type TopTracksResult = {
   tracks: Track[];
 };
 
-export type SnapshotReference = {
+type SnapshotReference = {
   snapshot_id: string;
 };
 
-export type PlaylistBase = {
+type PlaylistBase = {
   collaborative: boolean;
   description: string;
   external_urls: ExternalUrls;
@@ -289,7 +299,7 @@ export type PlaylistBase = {
   uri: string;
 };
 
-export type PlaylistedTrack<Item extends TrackItem = TrackItem> = {
+type PlaylistedTrack<Item extends TrackItem = TrackItem> = {
   added_at: string;
   added_by: AddedBy;
   is_local: boolean;
@@ -297,7 +307,7 @@ export type PlaylistedTrack<Item extends TrackItem = TrackItem> = {
   track: Item;
 };
 
-export type AddedBy = {
+type AddedBy = {
   external_urls: ExternalUrls;
   href: string;
   id: string;
@@ -305,27 +315,27 @@ export type AddedBy = {
   uri: string;
 };
 
-export type Playlist<Item extends TrackItem = TrackItem> = PlaylistBase & {
+type Playlist<Item extends TrackItem = TrackItem> = PlaylistBase & {
   tracks: Page<PlaylistedTrack<Item>>;
 };
 
-export type FeatureedPlaylists = {
+type FeatureedPlaylists = {
   message: string;
   playlists: Page<SimplifiedPlaylist>;
 };
 
-export type SimplifiedPlaylist = PlaylistBase & {
+type SimplifiedPlaylist = PlaylistBase & {
   tracks: TrackReference | null;
 };
 
-export type TrackReference = {
+type TrackReference = {
   href: string;
   total: number;
 };
 
-export type TrackItem = Track | Episode;
+type TrackItem = Track | Episode;
 
-export type Actions = {
+type Actions = {
   interrupting_playback: boolean;
   pausing: boolean;
   resuming: boolean;
@@ -338,7 +348,7 @@ export type Actions = {
   transferring_playback: boolean;
 };
 
-export type PlaybackState = {
+type PlaybackState = {
   device: Device;
   repeat_state: string;
   shuffle_state: boolean;
@@ -351,7 +361,7 @@ export type PlaybackState = {
   actions: Actions;
 };
 
-export type Device = {
+type Device = {
   id: string | null;
   is_active: boolean;
   is_private_session: boolean;
@@ -361,18 +371,18 @@ export type Device = {
   volume_percent: number | null;
 };
 
-export type Devices = {
+type Devices = {
   devices: Device[];
 };
 
-export type Context = {
+type Context = {
   type: string;
   href: string;
   external_urls: ExternalUrls;
   uri: string;
 };
 
-export type RecentlyPlayedTracks = {
+type RecentlyPlayedTracks = {
   href: string;
   limit: number;
   next: string | null;
@@ -384,13 +394,13 @@ export type RecentlyPlayedTracks = {
   items: PlayHistory[];
 };
 
-export type PlayHistory = {
+type PlayHistory = {
   track: Track;
   played_at: string;
   context: Context;
 };
 
-export type Queue = {
+type Queue = {
   currently_playing: TrackItem | null;
   queue: TrackItem[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,14 @@ export type Followers = {
   total: number;
 };
 
+export type LinkedFrom = {
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  type: string;
+  uri: string;
+};
+
 export type SimplifiedArtist = {
   external_urls: ExternalUrls;
   href: string;
@@ -54,31 +62,8 @@ export type Artist = SimplifiedArtist & {
   popularity: number;
 };
 
-export type LinkedFrom = {
-  external_urls: ExternalUrls;
-  href: string;
-  id: string;
-  type: string;
-  uri: string;
-};
-
-export type SimplifiedTrack = {
-  artists: SimplifiedArtist[];
-  available_markets: string[];
-  dics_number: number;
-  duration_ms: number;
-  explicit: boolean;
-  external_urls: ExternalUrls;
-  href: string;
-  id: string;
-  is_playable: boolean;
-  linked_from: LinkedFrom;
-  restrictions: Restrictions;
-  name: string;
-  track_number: number;
-  type: string;
-  uri: string;
-  is_local: boolean;
+export type Artists = {
+  artists: Artist[];
 };
 
 export type AlbumBase = {
@@ -133,4 +118,33 @@ export type AlbumTrack = {
 
 export type NewReleases = {
   albums: Page<SimplifiedAlbum>;
+};
+
+export type SimplifiedTrack = {
+  artists: SimplifiedArtist[];
+  available_markets: string[];
+  dics_number: number;
+  duration_ms: number;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  is_playable: boolean;
+  linked_from: LinkedFrom;
+  restrictions: Restrictions;
+  name: string;
+  track_number: number;
+  type: string;
+  uri: string;
+  is_local: boolean;
+};
+
+export type Track = SimplifiedTrack & {
+  album: SimplifiedAlbum;
+  external_ids: ExternalIds;
+  popularity: number;
+};
+
+export type TopTracksResult = {
+  tracks: Track[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,14 @@ export type SimplifiedChapter = {
   restrictions: Restrictions;
 };
 
+export type Chapters = {
+  chapters: Chapter[];
+};
+
+export type Chapter = SimplifiedChapter & {
+  audiobook: SimplifiedAudiobook;
+};
+
 export type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,20 +285,27 @@ type SavedShow = {
 type SimplifiedTrack = {
   artists: SimplifiedArtist[];
   available_markets: string[];
-  dics_number: number;
+  disc_number: number;
   duration_ms: number;
+  episode: boolean;
   explicit: boolean;
   external_urls: ExternalUrls;
   href: string;
   id: string;
+  is_local: boolean;
+  name: string;
+  track: boolean;
+  track_number: number;
   is_playable: boolean;
   linked_from: LinkedFrom;
   restrictions: Restrictions;
-  name: string;
-  track_number: number;
   type: string;
   uri: string;
-  is_local: boolean;
+};
+
+type SavedTrack = {
+  added_at: string;
+  track: Track;
 };
 
 type Track = SimplifiedTrack & {
@@ -307,7 +314,144 @@ type Track = SimplifiedTrack & {
   popularity: number;
 };
 
+type Tracks = {
+  tracks: Track[];
+};
+
 type TopTracksResult = {
+  tracks: Track[];
+};
+
+type AudioFeatures = {
+  acousticness: number;
+  analysis_url: string;
+  danceability: number;
+  duration_ms: number;
+  energy: number;
+  id: string;
+  instrumentalness: number;
+  key: number;
+  liveness: number;
+  loudness: number;
+  mode: number;
+  speechiness: number;
+  tempo: number;
+  time_signature: number;
+  track_href: string;
+  type: string;
+  uri: string;
+  valence: number;
+};
+
+type AudioFeaturesCollection = {
+  audio_features: AudioFeatures[];
+};
+
+type AudioAnalysis = {
+  meta: Meta;
+  track: TrackAnalysis;
+  bars: Bar[];
+  beats: Beat[];
+  sections: Section[];
+  segments: Segment[];
+  tatums: Tatum[];
+};
+
+type Meta = {
+  analyzer_version: string;
+  platform: string;
+  detailed_status: string;
+  status_code: number;
+  timestamp: number;
+  analysis_time: number;
+  input_process: number;
+};
+
+type TrackAnalysis = {
+  num_samples: number;
+  duration: number;
+  sample_md5: string;
+  offset_seconds: number;
+  window_seconds: number;
+  analysis_sample_rate: number;
+  analysis_channels: number;
+  end_of_fade_in: number;
+  end_of_fade_out: number;
+  loudness: number;
+  tempo: number;
+  tempo_confidence: number;
+  time_signature: number;
+  time_signature_confidence: number;
+  key: number;
+  key_confidence: number;
+  mode: number;
+  mode_confidence: number;
+  codestring: string;
+  code_version: number;
+  echoprintstring: string;
+  echoprint_version: number;
+  synchstring: string;
+  synch_version: number;
+  rhythmstring: string;
+  rhythm_version: number;
+};
+
+type Bar = {
+  start: number;
+  duration: number;
+  confidence: number;
+};
+
+type Beat = {
+  start: number;
+  duration: number;
+  confidence: number;
+};
+
+type Section = {
+  start: number;
+  duration: number;
+  confidence: number;
+  loudness: number;
+  tempo: number;
+  tempo_confidence: number;
+  key: number;
+  key_confidence: number;
+  mode: number;
+  mode_confidence: number;
+  time_signature: number;
+  time_signature_confidence: number;
+};
+
+type Segment = {
+  start: number;
+  duration: number;
+  confidence: number;
+  loudness_start: number;
+  loudness_max: number;
+  loudness_max_time: number;
+  loudness_end: number;
+  pitches: number[];
+  timbre: number[];
+};
+
+type Tatum = {
+  start: number;
+  duration: number;
+  confidence: number;
+};
+
+type RecommendationSeed = {
+  afterFilteringSize: number;
+  afterRelinkingSize: number;
+  href: string;
+  id: string;
+  initialPoolSize: number;
+  type: string;
+};
+
+type RecommendationsResponse = {
+  seeds: RecommendationSeed[];
   tracks: Track[];
 };
 


### PR DESCRIPTION
This PR adds some initial types from the spotify/spotify-web-api-ts-sdk project. The types can be separated into multiple files if need be. They are all currently not exported to make it easier to know which ones are used